### PR TITLE
Added in parenthesis.

### DIFF
--- a/Calculator/ViewModels/MainWindowViewModel.cs
+++ b/Calculator/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Calculator.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 

--- a/CalculatorTests/ParserTests.cs
+++ b/CalculatorTests/ParserTests.cs
@@ -1,4 +1,3 @@
-using Calculator;
 using Calculator.Models;
 using BinaryOperator = Calculator.Models.BinaryOperationExpression.BinaryOperator;
 
@@ -60,6 +59,22 @@ public class ParserTests
         AssertFloat(binOp.Left, a);
         AssertFloat(binOp.Right, b);
         Assert.That(binOp.Operator, Is.EqualTo(@operator));
+    }
+
+    [TestCase("1 + 2*3", 7f)]
+    [TestCase("(1 + 2)*3", 9f)]
+    [TestCase("1 + 2 * 3 + 4", 11f)]
+    public void TestExpression(string input, float expected)
+    {
+        var result = Parser.ParseExpression(input);
+        if (!result.WasSuccessful)
+        {
+            throw new Exception("Failed to parse!");
+        }
+
+        var eval = result.Value.Evaluate();
+
+        Assert.That(eval, Is.EqualTo(expected).Within(0.005f));
     }
 
     private static void AssertFloat(IExpression expression, float expected, float tolerance = 0.001f)


### PR DESCRIPTION
Added support of parenthesis, so now things like `(1+2)*3` correctly parse and output 9.

Closes #1.