### PR TITLE
Added constants.

### DIFF
--- a/Calculator/Models/EvaluationContext.cs
+++ b/Calculator/Models/EvaluationContext.cs
@@ -21,5 +21,5 @@ public sealed class EvaluationContext
     /// </summary>
     public FunctionRegistry Functions { get; set; } = new();
 
-    public Dictionary<string, double> Variables { get; set; } = [];
+    public VariableRegistry Variables { get; set; } = new();
 }

--- a/Calculator/Models/Expression.cs
+++ b/Calculator/Models/Expression.cs
@@ -152,7 +152,7 @@ public class VariableExpression(string name) : IExpression
 
     public double Evaluate(EvaluationContext context)
     {
-        if (!context.Variables.TryGetValue(Name, out var valueResult))
+        if (!context.Variables.TryGet(Name, out var valueResult))
         {
             return double.NaN;
         }

--- a/Calculator/Models/Variables.cs
+++ b/Calculator/Models/Variables.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace Calculator.Models;
+
+public class VariableRegistry
+{
+    private readonly Dictionary<string, double> _variables = [];
+    private readonly Dictionary<string, double> _constants = DefaultConstants();
+
+    public bool IsDefined(string name) => _variables.ContainsKey(name) || _constants.ContainsKey(name);
+    public bool IsConstant(string name) => _constants.ContainsKey(name);
+
+    #region Get & Set
+    public void AddConstant(string name, double value)
+    {
+        _constants.Add(name, value);
+    }
+
+    public void SetVariable(string name, double value)
+    {
+        _variables[name] = value;
+    }
+
+    public bool TryGet(string name, out double value)
+    {
+        if (!IsDefined(name))
+        {
+            value = 0;
+            return false;
+        }
+
+        if (!IsConstant(name))
+            value = _variables[name];
+        else
+            value = _constants[name];
+        return true;
+    }
+
+    #endregion
+
+    public double this[string name]
+    {
+        get
+        {
+            if (TryGet(name, out var value))
+                return value;
+            throw new KeyNotFoundException($"Variable {name} is not defined.");
+        }
+        set => _variables[name] = value;
+    }
+
+    private static Dictionary<string, double> DefaultConstants()
+    {
+        var constants = new Dictionary<string, double>();
+
+        constants["pi"] = double.Pi;
+        constants["e"] = double.E;
+        constants["gold"] = (1 + double.Sqrt(5)) / 2; // golden ratio
+
+        return constants;
+    }
+}

--- a/Calculator/Models/Variables.cs
+++ b/Calculator/Models/Variables.cs
@@ -55,6 +55,7 @@ public class VariableRegistry
         var constants = new Dictionary<string, double>();
 
         constants["pi"] = double.Pi;
+        constants["tau"] = double.Tau;
         constants["e"] = double.E;
         constants["gold"] = (1 + double.Sqrt(5)) / 2; // golden ratio
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A simple calculator app, made with avalonia!
 ## Features.
 
 - 4 function arithmetic, with proper order of operations,
-- Parenthesis,
-- and (some) Functions!
+- parenthesis,
+- some functions,
+- and, some constants. 
 
 ## Supported functions.
 
@@ -27,3 +28,14 @@ Currently, the following functions are supported:
 | `max(x, y)`  | Maximum of `x` and `y`.                                         |
 | `floor(x)`   | Rounds `x` down to the nearest integer.                         |
 | `ceil(x)`    | Rounds `x` up to the nearest integer.                           |
+
+## Constants
+
+There are 4 constants defined by default:
+
+| name   | approx value |                          description                           |
+| ------ | ------------ | -------------------------------------------------------------  |
+| `pi`   |   3.14159    | π, the ratio between a circle's circumference to its diameter. |
+| `tau`  |   6.28318    |   τ, the ratio between a circle's circumference and radius.    |
+| `e`    |              |         e, the natural logarithm/exponent constant.            |
+| `gold` |              |                      The golden ratio.                         |


### PR DESCRIPTION
Added in constants. See #10 for rationale. Ended up going with the 2nd method defined for implementation where I changed `EvaluationContext.Variables` to be a new class `VariableRegistry`.

4 constants are defined by default:

| name | approx value |                          description                           |
| ---- | ------------ | -------------------------------------------------------------  |
| pi   |   3.14159    | π, the ratio between a circle's circumference to its diameter. |
| tau  |   6.28318    |   τ, the ratio between a circle's circumference and radius.    |
| e    |              |         e, the natural logarithm/exponent constant.            |
| gold |              |                      The golden ratio.                         |